### PR TITLE
trusted_ca::ca and trusted_ca::java now have "content" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Many organizations use self-signed SSL certificates for internal services that n
 
 ### What trusted_ca affects
 
-* Distributin-provided trusted SSL certificates package
+* Distribution-provided trusted SSL certificates package
 * System-wide additional trusted SSL certificates
 * SSL certificates installed into java trusted certificate keystore
 
@@ -50,7 +50,7 @@ Manage only distribution-specific trusted certificates
     class { 'trusted_ca': }
 ```
 
-Install a self-signed SSL certificate into the system's global trusted keystore
+Install a self-signed SSL certificate into the system's global trusted keystore from a source file
 
 ```puppet
     class { 'trusted_ca': }
@@ -59,13 +59,22 @@ Install a self-signed SSL certificate into the system's global trusted keystore
     }
 ```
 
-Install a self-signed SSL certificate into a java keystore
+Install a self-signed SSL certificate into a java keystore from a source file
 
 ```puppet
     class { 'trusted_ca': }
     trusted_ca::java { 'mycompany.org':
       source => 'puppet:///ssl/mycompany.org/crt',
       java_keystore => '/usr/local/java/lib/security/cacerts',
+    }
+```
+
+Install a certificate into the system's global trusted keystore from a PEM-encoded string (eg from hiera)
+
+```puppet
+    class { 'trusted_ca': }
+    trusted_ca::ca { 'example.net':
+      content => hiera("example-net-x509"),
     }
 ```
 
@@ -92,12 +101,18 @@ String.  Location to install the trusted certificates.
 String.  Command to rebuild the system-trusted certificates.
 
 ### Public defines
-
+ 
 #### `trusted_ca::ca`
 
 ##### `source`
 
-String.  Source of the certificate to include.  Must be in PEM format with crt extension.
+String.  Source of the certificate to include.  Must be a file in PEM format with crt extension.
+You must specify either source or content, but not both. If source is specified, content is ignored.
+
+##### `content`
+
+String.  Content of certificate in PEM format.
+You must specify either source or content, but not both. If source is specified, content is ignored.
 
 ##### `install_path`
 
@@ -107,7 +122,13 @@ String.  Destination of the certificate file for processing.  Defaults to the in
 
 ##### `source`
 
-String.  Source of the certificate to include.  Must be in PEM format.
+String.  Source of the certificate to include.  Must be a file in PEM format with crt extension.
+You must specify either source or content, but not both. If source is specified, content is ignored.
+
+##### `content`
+
+String.  Content of certificate in PEM format.
+You must specify either source or content, but not both. If source is specified, content is ignored.
 
 ##### `java_keystore`
 
@@ -122,6 +143,8 @@ String.  Location of of the java cacerts keystore file.
 Tested on:
 * CentOS 6, 7
 * Ubuntu Server 10.04, 12.04, 14.04
+
+This module assumes the keytool and openssl utilities are available.
 
 ## Development
 

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -5,11 +5,19 @@
 #
 # === Parameters
 #
-# [*source*]
-#   String.  Path to the certificate PEM.
-#
 # [*java_keystore*]
 #   String.  Location of java cacerts file
+#   This must be specified - there is no default.
+#
+# [*source*]
+#   String.  Path to the certificate PEM.
+#   Must specify either content or source.
+#   If source is specified, content is ignored.
+#
+# [*content*]
+#   String.  Content of certificate in PEM format.
+#   Must specify either content or source.
+#   If source is specified, content is ignored.
 #
 #
 # === Examples
@@ -17,27 +25,75 @@
 # * Installation:
 #     class { 'trusted_ca': }
 #
-#     trusted_ca::ca { 'example.org.local':
+#     trusted_ca::java { 'example.org.local':
 #       source  => puppet:///data/ssl/example.com.pem
 #     }
 #
+#     trusted_ca::java { 'example.net.local':
+#       content  => hiera("example-net-x509")
+#     }
+#
+# === Authors
+#
+# * Justin Lambert <mailto:jlambert@letsevenup.com>
 #
 define trusted_ca::java (
-  $source,
   $java_keystore,
+  $source       = undef,
+  $content      = undef,
 ) {
 
-  file { "/tmp/${name}-trustedca":
-    source  => $source,
+  if ! defined(Class['trusted_ca']) {
+    fail('You must include the trusted_ca base class before using any trusted_ca defined resources')
   }
 
-  exec { "import ${name} to java":
-    command   => "keytool -import -noprompt -trustcacerts -alias ${name} -file /tmp/${name}-trustedca -keystore ${java_keystore} -storepass changeit",
-    cwd       => '/tmp',
-    path      => '/bin/:/usr/bin/',
-    logoutput => on_failure,
-    unless    => "echo '' | keytool -list -keystore ${java_keystore} | grep ${name}",
-    require   => File["/tmp/${name}-trustedca"],
+  if $source and $content {
+    fail('You must not specify both $source and $content for trusted_ca defined resources')
+  }
+
+  if $source {
+
+    file { "/tmp/${name}-trustedca":
+      ensure => 'file',
+      source => $source,
+      notify => Exec["validate /tmp/${name}-trustedca"],
+      mode   => '0644',
+      owner  => 'root',
+      group  => 'root',
+    }
+
+  } elsif $content {
+
+    file { "/tmp/${name}-trustedca":
+      ensure  => 'file',
+      content => $content,
+      notify  => Exec["validate /tmp/${name}-trustedca"],
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+    }
+  } else {
+    fail('You must specify either $source and $content for trusted_ca defined resources')
+  }
+
+  # This makes sure the certificate is valid
+  exec {"validate /tmp/${name}-trustedca":
+    command     => "openssl x509 -in /tmp/${name}-trustedca -noout",
+    logoutput   => on_failure,
+    path        => $::trusted_ca::path,
+    notify      => Exec["import ${name} to jks ${java_keystore}"],
+    returns     => 0,
+    refreshonly => true,
+  }
+
+  exec { "import /tmp/${name}-trustedca to jks ${java_keystore}":
+    command     => "keytool -import -noprompt -trustcacerts -alias ${name} -file /tmp/${name}-trustedca -keystore ${java_keystore} -storepass changeit",
+    cwd         => '/tmp',
+    path        => $::trusted_ca::path,
+    logoutput   => on_failure,
+    unless      => "echo '' | keytool -list -keystore ${java_keystore} | grep ${name}",
+    require     => File["/tmp/${name}-trustedca"],
+    refreshonly => true,
   }
 
 }

--- a/spec/defines/trusted_ca_ca_spec.rb
+++ b/spec/defines/trusted_ca_ca_spec.rb
@@ -13,6 +13,21 @@ describe 'trusted_ca::ca', :type => :define do
       it { expect { should create_define('trusted_ca::ca') }.to raise_error }
     end
 
+    context 'bad content' do
+      let(:params) { { :source => Nil, :content => 'foo' } }
+      it { expect { should create_define('trusted_ca::ca') }.to raise_error }
+    end
+
+    context 'specifying both source and content' do
+      let(:params) { { :content => 'foo' } }
+      it { expect { should create_define('trusted_ca::ca') }.to raise_error }
+    end
+
+    context 'specifying neither source nor content' do
+      let(:params) { { :content => Nil, :source => Nil } }
+      it { expect { should create_define('trusted_ca::ca') }.to raise_error }
+    end
+
     context 'not including trusted_ca' do
       let(:pre_condition) {}
       it { expect { should create_define('trusted_ca::ca') }.to raise_error }
@@ -25,7 +40,7 @@ describe 'trusted_ca::ca', :type => :define do
     context 'default' do
       it { should contain_file('/etc/pki/ca-trust/source/anchors/mycert.crt').with(
         :source => 'puppet:///data/mycert.crt',
-        :notify => "Exec[update_system_certs]"
+        :notify => "Exec[validate /etc/pki/ca-trust/source/anchors/mycert.crt]"
       ) }
     end
 
@@ -37,10 +52,9 @@ describe 'trusted_ca::ca', :type => :define do
     context 'default' do
       it { should contain_file('/usr/local/share/ca-certificates/mycert.crt').with(
         :source => 'puppet:///data/mycert.crt',
-        :notify => "Exec[update_system_certs]"
+        :notify => "Exec[validate /usr/local/share/ca-certificates/mycert.crt]"
       ) }
     end
   end
 
 end
-

--- a/spec/defines/trusted_ca_java_spec.rb
+++ b/spec/defines/trusted_ca_java_spec.rb
@@ -2,13 +2,44 @@ require 'spec_helper'
 
 describe 'trusted_ca::java', :type => :define do
   let(:title) { 'mycert' }
+  let(:pre_condition) { 'include trusted_ca' }
   let(:params) { {
     :source => 'puppet:///data/mycert.crt',
     :java_keystore => '/etc/alternatives/jre_1.7.0/lib/security/cacerts'
   } }
 
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystemmajrelease => '6' } }
+
+  context 'validations' do
+
+    context 'bad source' do
+      let(:params) { { :source => 'foo' } }
+      it { expect { should create_define('trusted_ca::java') }.to raise_error }
+    end
+
+    context 'bad content' do
+      let(:params) { { :source => Nil, :content => 'foo' } }
+      it { expect { should create_define('trusted_ca::java') }.to raise_error }
+    end
+
+    context 'specifying both source and content' do
+      let(:params) { { :content => 'foo' } }
+      it { expect { should create_define('trusted_ca::java') }.to raise_error }
+    end
+
+    context 'specifying neither source nor content' do
+      let(:params) { { :content => Nil, :source => Nil } }
+      it { expect { should create_define('trusted_ca::java') }.to raise_error }
+    end
+
+    context 'not including trusted_ca' do
+      let(:pre_condition) {}
+      it { expect { should create_define('trusted_ca::java') }.to raise_error }
+    end
+  end
+
   it { should contain_file('/tmp/mycert-trustedca') }
-  it { should contain_exec('import mycert to java').with(
+  it { should contain_exec('import /tmp/mycert-trustedca to jks /etc/alternatives/jre_1.7.0/lib/security/cacerts').with(
     :command => 'keytool -import -noprompt -trustcacerts -alias mycert -file /tmp/mycert-trustedca -keystore /etc/alternatives/jre_1.7.0/lib/security/cacerts -storepass changeit'
   )}
 


### PR DESCRIPTION
Wasn't sure how to properly automate testing the new content parameter via rspec; doing so would need a PEM-encoded x509 certificate to be captured in a variable somehow (eg, a hiera lookup?), which exceeds my unit test writing abilities ...