### PR TITLE
Add Support for Suse osfamily, tested on SLES 11 SP3, and OpenSuSE 13.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Install a certificate into the system's global trusted keystore from a PEM-encod
 
 String.  Version of the distribution-specific trusted certificates.  Examples would be 'latest' or a specific version.
 
+##### `certs_package`
+
+String.  Package name of the distribution-specific trusted certificates. Default is OS/Distribution specific.
+
 ##### `path`
 
 String/Array of String.  List of paths for the `update_command`.
@@ -99,6 +103,10 @@ String.  Location to install the trusted certificates.
 ##### `update_command`
 
 String.  Command to rebuild the system-trusted certificates.
+
+##### `certfile_suffix`
+
+String.  Suffix of certificate files. Default is OS/Distribution dependent, i.e. 'pem' or 'crt'.
 
 ### Public defines
  
@@ -117,6 +125,10 @@ You must specify either source or content, but not both. If source is specified,
 ##### `install_path`
 
 String.  Destination of the certificate file for processing.  Defaults to the install_path from the class, but can be overridden per certificate.
+
+##### `certfile_suffix`
+
+String.  Suffix of certificate files. Default is OS/Distribution dependent, i.e. 'pem' or 'crt'.
 
 #### `trusted_ca::java`
 
@@ -143,6 +155,8 @@ String.  Location of of the java cacerts keystore file.
 Tested on:
 * CentOS 6, 7
 * Ubuntu Server 10.04, 12.04, 14.04
+* SLES 11 SP3
+* OpenSuSE 13.1
 
 This module assumes the keytool and openssl utilities are available.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,8 @@ class trusted_ca (
   $path                 = $::trusted_ca::params::path,
   $install_path         = $::trusted_ca::params::install_path,
   $update_command       = $::trusted_ca::params::update_command,
+  $certfile_suffix      = $::trusted_ca::params::certfile_suffix,
+  $certs_package        = $::trusted_ca::params::certs_package,
 ) inherits trusted_ca::params {
 
   if is_array($path) {
@@ -36,7 +38,7 @@ class trusted_ca (
     $_path = $path
   }
 
-  package { 'ca-certificates':
+  package { $certs_package:
     ensure  => $certificates_version,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,8 @@ class trusted_ca::params {
       $path = [ '/usr/bin', '/bin']
       $update_command = 'update-ca-trust enable && update-ca-trust'
       $install_path = '/etc/pki/ca-trust/source/anchors'
+      $certfile_suffix = 'crt'
+      $certs_package = 'ca-certificates'
 
       case $::operatingsystemmajrelease {
         '6', '7': {
@@ -21,12 +23,35 @@ class trusted_ca::params {
       $path = ['/bin', '/usr/bin', '/usr/sbin']
       $update_command = 'update-ca-certificates'
       $install_path = '/usr/local/share/ca-certificates'
+      $certfile_suffix = 'crt'
+      $certs_package = 'ca-certificates'
 
       case $::operatingsystemrelease {
         '12.04', '14.04': {
         }
         default: {
           fail("${::osfamily} ${::operatingsystemrelease} has not been tested with this module.  Please feel free to test and report the results")
+        }
+      }
+    }
+    'Suse': {
+      case $::operatingsystem {
+        'SLES': {
+          $path = ['/usr/bin']
+          $update_command = 'c_rehash'
+          $install_path = '/etc/ssl/certs'
+          $certfile_suffix = 'pem'
+          $certs_package = 'openssl-certs'
+        }
+        'OpenSuSE': {
+          $path = ['/usr/sbin', '/usr/bin']
+          $update_command = 'update-ca-certificates'
+          $install_path = '/etc/pki/trust/anchors'
+          $certfile_suffix = 'pem'
+          $certs_package = 'ca-certificates'
+        }
+        default: {
+          fail("${::osfamily}/${::operatingsystem} not supported")
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,8 @@
   "operatingsystem_support": [
     { "operatingsystem": "RedHat", "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6", "7" ] },
+    { "operatingsystem": "OpenSuSE", "operatingsystemrelease": [ "13.1" ] },
+    { "operatingsystem": "SLES", "operatingsystemrelease": [ "11" ] },
     { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "10.04", "12.04", "14.04" ] }
   ],
   "dependencies": [

--- a/spec/defines/trusted_ca_ca_spec.rb
+++ b/spec/defines/trusted_ca_ca_spec.rb
@@ -57,4 +57,28 @@ describe 'trusted_ca::ca', :type => :define do
     end
   end
 
+  context 'on Suse SLES' do
+    let(:facts) { { :osfamily => 'Suse', :operatingsystem => 'SLES' } }
+    let(:params) { { :source => 'puppet:///data/mycert.pem' } }
+
+    context 'default' do
+      it { should contain_file('/etc/ssl/certs/mycert.pem').with(
+        :source => 'puppet:///data/mycert.pem',
+        :notify => "Exec[validate /etc/ssl/certs/mycert.pem]"
+      ) }
+    end
+  end
+
+  context 'on Suse OpenSuSE' do
+    let(:facts) { { :osfamily => 'Suse', :operatingsystem => 'OpenSuSE' } }
+    let(:params) { { :source => 'puppet:///data/mycert.pem' } }
+
+    context 'default' do
+      it { should contain_file('/etc/pki/trust/anchors/mycert.pem').with(
+        :source => 'puppet:///data/mycert.pem',
+        :notify => "Exec[validate /etc/pki/trust/anchors/mycert.pem]"
+      ) }
+    end
+  end
+
 end


### PR DESCRIPTION
Added osfamily Suse to params.pp, and had to add a few new
Distribution specific variables there, besides those that are
already usble:

certfile_suffix: to specify the default suffix, its 'pem' on Suse
certs_package: the name of the os specific package that provides
               the general certificate files.

For the update_command, I just use the c_rehash tool that comes
from openssl package. The certificates are installed in /etc/ssl/certs.
c_rehash doesn't pick up .crt files, for that reason, above mentioned
certfile_suffix OS specific parameter is introduced.

In manifests/ca.pp, I had to use a workaround a bit, since
variable interpolation within regular expressions is not possible
in Puppet, I had to revert to use an inline_template and make
it work with Ruby.

Note: I only looked at the java.pp, haven't tested it, since
I don't need it, but from looking it seems it doesn't need
any changes.

Updated README.md mentioning the new parameters, and the testing
on SLES and OpenSuSE, also updated metadata.json.

Further added a test for Suse to the specs for the ca defined type.

Feedback appreciated, let me know if there is something not good and I'm happy to change it.