### PR TITLE
Edited java.pp manifest to fix invalid relationship

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -81,7 +81,7 @@ define trusted_ca::java (
     command     => "openssl x509 -in /tmp/${name}-trustedca -noout",
     logoutput   => on_failure,
     path        => $::trusted_ca::path,
-    notify      => Exec["import ${name} to jks ${java_keystore}"],
+    notify      => Exec["import /tmp/${name}-trustedca to jks ${java_keystore}"],
     returns     => 0,
     refreshonly => true,
   }


### PR DESCRIPTION
When Puppet evaluates the relationship, it's looking for a resource:
Exec[import ${name} to jks ${java_keystore}]
however the actual name of the resource as defined in the manifest is:
Exec[import /tmp/${name}-trustedca to jks ${java_keystore}]